### PR TITLE
Activate dispatch backend on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,12 @@ PUBLIC
 if (LINUX)
     target_link_libraries(lib_crl
     PUBLIC
+        desktop-app::external_dispatch
         pthread
     )
-elseif (build_macstore)
+endif()
+
+if (build_macstore OR LINUX)
     target_compile_definitions(lib_crl
     PUBLIC
         CRL_USE_COMMON_QUEUE

--- a/crl/common/crl_common_config.h
+++ b/crl/common/crl_common_config.h
@@ -33,12 +33,21 @@
 #define CRL_USE_WINAPI_LIST
 #endif // !CRL_FORCE_STD_LIST
 
-#elif defined __APPLE__ && !defined CRL_FORCE_QT // _MSC_VER && !CRL_FORCE_QT
+#elif !defined CRL_FORCE_QT // _MSC_VER && !CRL_FORCE_QT
+
+// gcc compatibility
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif // !__has_feature
+
+#ifndef __has_extension
+#define __has_extension __has_feature
+#endif // !__has_extension
 
 #define CRL_USE_DISPATCH
 #define CRL_USE_COMMON_LIST
 
-#elif __has_include(<QtCore/QThreadPool>) // __APPLE__ && !CRL_FORCE_QT
+#elif __has_include(<QtCore/QThreadPool>) // !CRL_FORCE_QT
 
 #define CRL_USE_QT
 #define CRL_USE_COMMON_LIST


### PR DESCRIPTION
Linux is the only platform where slow QThreadPool is used, let's use dispatch here as well