### PR TITLE
Fix build without dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ if (TARGET desktop-app::external_dispatch)
     PUBLIC
         desktop-app::external_dispatch
     )
+else()
+    target_compile_definitions(lib_crl
+    PUBLIC
+        CRL_FORCE_QT
+    )
 endif()
 
 if (build_macstore OR TARGET desktop-app::external_dispatch)


### PR DESCRIPTION
Building tdesktop without the relatively new dependency on dispatch
still works, except that current lib_crl expects it to be enabled.

Fall back to Qt if dispatch is not used to fix the build:
```
/usr/ports/pobj/tdesktop-3.3.1/tdesktop-3.3.1-full/Telegram/lib_crl/crl/dispatch/crl_dispatch_async.cpp:11:10: fatal error: 'dispatch/dispatch.h' file not found
```

dispatch does not (yet) work on OpenBSD, so I've been building the
official net/tdesktop port with a global `CXXFLAGS += -DCRL_FORCE_QT`
ever since the introduction of dispatch.

This patch is meant to fix lib_crl proper, regarless of why and how
tdesktop is built without dispatch.
