### PR TITLE
Replace call to std::atomic<bool>::compare_exchange_strong with std::atomic_flag::test_and_set

### DIFF
--- a/crl/common/crl_common_queue.h
+++ b/crl/common/crl_common_queue.h
@@ -54,7 +54,7 @@ private:
 
 	main_queue_processor _main_processor = nullptr;
 	details::list _list;
-	std::atomic<bool> _queued = false;
+	std::atomic_flag _queued = ATOMIC_FLAG_INIT;
 
 };
 

--- a/crl/crl_object_on_thread.cpp
+++ b/crl/crl_object_on_thread.cpp
@@ -22,7 +22,7 @@ void thread_policy::run() {
 		if (!_list.process()) {
 			break;
 		}
-		_queued.store(false);
+		_queued.clear();
 
 		std::unique_lock<std::mutex> lock(_mutex);
 		_variable.wait(lock, [=] { return !_list.empty(); });
@@ -30,8 +30,7 @@ void thread_policy::run() {
 }
 
 void thread_policy::wake_async() const {
-	auto expected = false;
-	if (_queued.compare_exchange_strong(expected, true)) {
+	if (!_queued.test_and_set()) {
 		std::unique_lock<std::mutex> lock(_mutex);
 		_variable.notify_one();
 	}

--- a/crl/crl_object_on_thread.h
+++ b/crl/crl_object_on_thread.h
@@ -27,7 +27,7 @@ private:
 	mutable std::mutex _mutex;
 	mutable std::condition_variable _variable;
 	mutable details::list _list;
-	mutable std::atomic<bool> _queued = false;
+	mutable std::atomic_flag _queued = ATOMIC_FLAG_INIT;
 
 };
 


### PR DESCRIPTION
No regressions noticed but this makes possible building on RISC-V 64bit without necessary linking against libatomic.