### PR TITLE
🩹 Disable libdispatch support

### DIFF
--- a/crl/common/crl_common_config.h
+++ b/crl/common/crl_common_config.h
@@ -31,20 +31,7 @@
 #define CRL_USE_WINAPI_LIST
 #endif // !CRL_FORCE_COMMON_LIST
 
-#elif __has_include(<dispatch/dispatch.h>) && !defined CRL_FORCE_QT // _MSC_VER && !CRL_FORCE_QT
-
-// gcc compatibility
-#ifndef __has_feature
-#define __has_feature(x) 0
-#endif // !__has_feature
-
-#ifndef __has_extension
-#define __has_extension __has_feature
-#endif // !__has_extension
-
-#define CRL_USE_DISPATCH
-
-#elif __has_include(<tmc/ex_cpu.hpp>) && !defined CRL_FORCE_QT // dispatch && !CRL_FORCE_QT
+#elif __has_include(<tmc/ex_cpu.hpp>) && !defined CRL_FORCE_QT // _MSC_VER && !CRL_FORCE_QT
 
 #define CRL_USE_TMC
 


### PR DESCRIPTION
_Hello everyone,_

_As [a proxied maintainer](https://packages.gentoo.org/maintainer/aliaksei.urbanski@gmail.com), I'm working on updating [net-im/telegram-desktop](https://packages.gentoo.org/packages/net-im/telegram-desktop) package of [Gentoo Linux](https://www.gentoo.org)._

**Telegram Desktop** [6.9.2](https://github.com/telegramdesktop/tdesktop/releases/tag/v6.9.2) build [fails](https://github.com/user-attachments/files/28877383/telegram-desktop-6.9.2.20260612-100811.log) in case [libdispatch](https://packages.gentoo.org/packages/dev-libs/libdispatch) is installed.
Removing `#define CRL_USE_DISPATCH` fixes that.

_Best regards!_

_P.S. You can usually find fresh `net-im/telegram-desktop` ebuilds in [my overlay](https://github.com/Jamim/gentoo-overlay)._