### PR TITLE
ensure initialization of tmc::cpu_executor is complete before use

### DIFF
--- a/crl/tmc/crl_tmc_async.h
+++ b/crl/tmc/crl_tmc_async.h
@@ -18,9 +18,19 @@
 
 namespace crl::details {
 
+inline void ensure_tmc_cpu_executor_init() {
+    // init() is idempotent, but doesn't block other callers while executing.
+    // This static initializer protects against multiple execution, and
+    // concurrent callers block here until it finishes, ensuring that the 
+    // executor is fully initialized before post(). Subsequent calls are
+    // just a cheap acquire-load of the guard variable.
+    static int once = (tmc::cpu_executor().init(), 0);
+    (void)once;
+}
+
 template <typename Callable>
 inline void async_any(Callable &&callable) {
-    tmc::cpu_executor().init();
+    ensure_tmc_cpu_executor_init();
     tmc::post(tmc::cpu_executor(), std::forward<Callable>(callable));
 }
 


### PR DESCRIPTION
Hey, TooManyCooks author here. Glad to be included.

I see a potential problem with the current implementation - while `init()` is idempotent and safe to call multiple times, it doesn't block other callers until it completes. That can result in the following race condition:
1. Thread 1 calls async_any() -> init() takes the unique initializer lock.
2. Thread 2 calls async_any() -> init() sees that the executor initializer lock was taken, and returns immediately.
3. Thread 2 calls tmc::post(tmc::cpu_executor(), ...) before initialization is complete. This will cause a crash.
4. Thread 1 completes init(), too late.

There are a few options to solve this problem:
- Eager: call `tmc::cpu_executor().init()` at the top of `main()` before doing anything else.
- Lazy: use a magic static which will delay execution of `init()` until it is called, and block other callers until it completes.

I've provided an implementation of the lazy-init fix in this PR, which doesn't require any other API changes.